### PR TITLE
Fix CurrentPlayer

### DIFF
--- a/socha-client-csharp/Backend/Board.cs
+++ b/socha-client-csharp/Backend/Board.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using Xml;
 
 namespace SochaClient
 {
@@ -40,6 +42,19 @@ namespace SochaClient
         public static bool IsInBounds(int x, int y) => x >= 0 && x < Width && y >= 0 && y < Height;
 
         /// <summary>
+        /// Returns all Fields that the given player has pieces on
+        /// </summary>
+        public Field[] GetFieldsOfPlayer(PlayerTeam team)
+        {
+            var re = new List<Field>();
+            for (int x = 0; x < Width; x++)
+                for (int y = 0; y < Height; y++)
+                    if (Fields[x, y].Piece.Team == team)
+                        re.Add(Fields[x, y]);
+            return re.ToArray();
+        }
+
+        /// <summary>
         /// Returns possible vectors for all Directions in hexspace
         /// </summary>
         public static Point[] GetNeighbors(Point pos) => pos.Y % 2 == 0 ? EvenHexNeighbors : OddHexNeighbors;
@@ -47,6 +62,20 @@ namespace SochaClient
         /// Returns a vector that points in the given Direction in hexspace
         /// </summary>
         public static Point GetDirectionDisplacement(Direction d, Point pos) => GetNeighbors(pos)[(int)d];
+        /// <summary>
+        /// Returns all neighboring fields of a field on the board
+        /// </summary>
+        public Field[] GetNeighborFields(Field f)
+        {
+            var ps = GetNeighbors(f.Position());
+            var rs = new List<Field>();
+
+            foreach (var p in ps)
+                if (IsInBounds(p))
+                    rs.Add(GetField(p));
+
+            return rs.ToArray();
+        }
 
         /// <summary>
         /// Creates a deep copy of this object

--- a/socha-client-csharp/Backend/Field.cs
+++ b/socha-client-csharp/Backend/Field.cs
@@ -20,7 +20,13 @@ namespace SochaClient
             this.Y = y;
         }
 
+        /// <summary>
+        /// No piece and no fishes on this field
+        /// </summary>
         public bool Empty() => Piece == null && fishes == 0;
+        /// <summary>
+        /// No piece but some fishes on this field
+        /// </summary>
         public bool Free() => Piece == null && fishes != 0;
         public Point Position() => new(X, Y);
         public Color ToColor() => Piece == null ? Color.FromArgb(0,0,fishes*50) : Piece.ToColor();

--- a/socha-client-csharp/Backend/Program.cs
+++ b/socha-client-csharp/Backend/Program.cs
@@ -144,6 +144,7 @@ Usage: start.sh [options]
             
             while (true)
             {
+                // Recieve text over netowrk and preprocess it
                 string recieved = Recieve(stream);
                 recieved = recieved.StartsWith("<protocol>") ? recieved.Remove(0, "<protocol>".Length) : recieved;
                 recieved = "<received>" + recieved + "</received>";
@@ -152,10 +153,12 @@ Usage: start.sh [options]
                 if (recieved.Contains("</protocol>"))
                     break;
 
+                // Serialize preprocessed text
                 var serializer = new XmlSerializer(typeof(Received));
                 StringReader stringReader = new(recieved);
                 var recievedObjs = (Received)serializer.Deserialize(stringReader);
 
+                // Handle XML object
                 if (recievedObjs.Joined != null)
                     RoomID = recievedObjs.Joined.RoomId;
                 if (recievedObjs.Left != null && recievedObjs.Left.RoomId == RoomID)
@@ -166,6 +169,7 @@ Usage: start.sh [options]
                             if (r.Data.Class == "moveRequest")
                             {
                                 Debug.WriteLine("Got MoveReq");
+
                                 Send(stream, (LastMove = playerLogic.GetMove()).ToXML());
                             }
                             else if (r.Data.Class == "memento")

--- a/socha-client-csharp/Backend/Program.cs
+++ b/socha-client-csharp/Backend/Program.cs
@@ -170,6 +170,13 @@ Usage: start.sh [options]
                             {
                                 Debug.WriteLine("Got MoveReq");
 
+                                if (gameState.Turn == 0)
+                                    gameState.MyselfPlayer = gameState.GetPlayer(gameState.StartTeam);
+                                else if (gameState.Turn == 1)
+                                    gameState.MyselfPlayer = gameState.GetOtherPlayer(gameState.GetPlayer(gameState.StartTeam));
+
+                                gameState.CurrentPlayer = gameState.MyselfPlayer;
+
                                 Send(stream, (LastMove = playerLogic.GetMove()).ToXML());
                             }
                             else if (r.Data.Class == "memento")

--- a/socha-client-csharp/Backend/State.cs
+++ b/socha-client-csharp/Backend/State.cs
@@ -19,7 +19,7 @@ namespace SochaClient
         public Board Board;
         public Player PlayerOne, PlayerTwo;
         public Move LastMove;
-        public Player CurrentPlayer;
+        public Player CurrentPlayer, MyselfPlayer;
 
         public State()
         {

--- a/socha-client-csharp/Backend/State.cs
+++ b/socha-client-csharp/Backend/State.cs
@@ -96,6 +96,22 @@ namespace SochaClient
         }
 
         /// <summary>
+        /// Checks whether the given player can move
+        /// </summary>
+        public bool CanMove(Player player)
+        {
+            var can = false;
+
+            foreach (var f in Board.GetFieldsOfPlayer(player.Team))
+            {
+                var n = Board.GetNeighborFields(f);
+                can &= n.Any(x => x.Free());
+            }
+
+            return can;
+        }
+
+        /// <summary>
         /// Get a Player object from the PlayerTeam enum
         /// </summary>
         public Player GetPlayer(PlayerTeam team)

--- a/socha-client-csharp/Backend/State.cs
+++ b/socha-client-csharp/Backend/State.cs
@@ -30,8 +30,6 @@ namespace SochaClient
 
         /// <summary>
         /// Returns a new State which represents the board after doing the given Move
-        /// <para>Caution: This method will check if the Move is legal before performing it which results 
-        /// in worse performance. If you are using this method a lot I recommend using PerformWithoutChecks</para>
         /// </summary>
         public State Perform(Move m)
         {
@@ -43,7 +41,8 @@ namespace SochaClient
         /// <summary>
         /// Returns a new State which represents the board after doing the given Move
         /// <para>Caution: This method won't check if the move is legal before commiting it to the board. 
-        /// Feeding illegal moves into this method may result in unexpected behavior</para>
+        /// Feeding illegal moves into this method may result in unexpected behavior.
+        /// However, it should run faster that Perform()</para>
         /// </summary>
         public State PerformWithoutChecks(Move m)
         {
@@ -59,7 +58,10 @@ namespace SochaClient
             targetField.Piece = startField.Piece;
             startField.Piece = null;
 
-            
+            // Update current player
+            var otherPlayer = GetOtherPlayer(CurrentPlayer);
+            if (CanMove(otherPlayer)) 
+                CurrentPlayer = otherPlayer;
 
             re.Turn++;
 
@@ -71,7 +73,7 @@ namespace SochaClient
         /// </summary>
         public Move[] GetAllPossibleMoves()
         {
-            List<Move> re = new List<Move>();
+            var re = new List<Move>();
 
             if (Turn < 8)
             {

--- a/socha-client-csharp/Backend/State.cs
+++ b/socha-client-csharp/Backend/State.cs
@@ -19,7 +19,7 @@ namespace SochaClient
         public Board Board;
         public Player PlayerOne, PlayerTwo;
         public Move LastMove;
-        public Player CurrentPlayer { get => Turn % 2 == 0 ? PlayerOne : PlayerTwo; }
+        public Player CurrentPlayer;
 
         public State()
         {
@@ -58,6 +58,8 @@ namespace SochaClient
             // Update board fields
             targetField.Piece = startField.Piece;
             startField.Piece = null;
+
+            
 
             re.Turn++;
 
@@ -121,6 +123,10 @@ namespace SochaClient
             else
                 return PlayerTwo;
         }
+        /// <summary>
+        /// Get the other Player from a player
+        /// </summary>
+        public Player GetOtherPlayer(Player player) => GetPlayer(player.Team.OtherTeam());
 
         /// <summary>
         /// Creates a deep copy of this object


### PR DESCRIPTION
Fix currentplayer not being set correctly at the end of the game.
In penguins who's turn it is is not only based on the turn number being odd or even but instead on who is able to move unlike in previous years' games.